### PR TITLE
Fixed typo in fileDir-Check

### DIFF
--- a/WindowsPatchApp/Source/PatchAPK/PatchAPK/Form1.cs
+++ b/WindowsPatchApp/Source/PatchAPK/PatchAPK/Form1.cs
@@ -265,7 +265,7 @@ namespace PatchAPK
 
             }
             doPatch("origin");
-            if (File.Exists(patchdir + "so2.bspatch"))
+            if (File.Exists(patchdir + "\\" + "so2.bspatch"))
             {
                 bsPatch2();
             }


### PR DESCRIPTION
Path was not concatenated correctly, so if-statement always returned false